### PR TITLE
Update values for PicoMMU

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1747,10 +1747,10 @@ questionaire() {
             _hw_variable_bowden_lengths=0
             _hw_variable_rotation_distances=0
             _hw_require_bowden_move=1
-            _hw_filament_always_gripped=1
-            _hw_gear_gear_ratio="1.28:1"
+            _hw_filament_always_gripped=0
+            _hw_gear_gear_ratio="1.25:1"
             _hw_gear_run_current=0.7
-            _hw_gear_hold_current=0.1
+            _hw_gear_hold_current=0.4
             _hw_chain_count=4
             _hw_exit_leds="neopixel:mmu_leds (1-4)"
             _hw_entry_leds=""
@@ -2242,6 +2242,7 @@ questionaire() {
             echo -e "${PROMPT}${SECTION}Which servo are you using?${INPUT}"
             OPTIONS=()
             option MMX_BOM 'MG996R'
+            option EMAX_ES3004 'EMAX ES3004'
             option OTHER 'Not listed / Other'
             prompt_option opt 'Servo' "${OPTIONS[@]}"
             case $opt in
@@ -2253,6 +2254,13 @@ questionaire() {
                     _param_servo_duration=0.6
                     _param_servo_dwell=1.0
                     ;;
+                "$EMAX_ES3004")
+                    _hw_maximum_servo_angle=140
+                    _hw_minimum_pulse_width=0.00070
+                    _hw_maximum_pulse_width=0.00230
+                    _param_servo_always_active=0
+                    _param_servo_duration=0.6
+                    _param_servo_dwell=1.2
                 *)
                     _hw_maximum_servo_angle=180
                     _hw_minimum_pulse_width=0.001

--- a/install.sh
+++ b/install.sh
@@ -1750,7 +1750,7 @@ questionaire() {
             _hw_filament_always_gripped=0
             _hw_gear_gear_ratio="1.25:1"
             _hw_gear_run_current=0.7
-            _hw_gear_hold_current=0.4
+            _hw_gear_hold_current=0.1
             _hw_chain_count=4
             _hw_exit_leds="neopixel:mmu_leds (1-4)"
             _hw_entry_leds=""


### PR DESCRIPTION
Updated some values to match LH's PicoMMU current standards for Servo and Stepper motor for ease of adoption for people using HH directly or moving from PicoMMU's own gcode:

* [BOM](https://github.com/lhndo/LH-Stinger/tree/main/User_Mods/MMU/Stinger%20Pico%20MMU%20-%20%40LH#bom) uses an EMAX ES3004 Servo, which has 140º of motion and uses a 1.2 seconds wait for servo to reach target values.  See https://github.com/lhndo/LH-Stinger/blob/main/User_Mods/MMU/Stinger%20Pico%20MMU%20-%20%40LH/Klipper/sp_mmu.cfg#L39-L44

* Stepper Motor gear ratio should be 1.25:1 since the input gear has 20 teeth and the output gear has 25 teeth. See 
![image](https://github.com/user-attachments/assets/a1c74f62-afb1-4d6a-ad8a-eb37959c85e9)
(screenshot taken from [3MF file](https://github.com/lhndo/LH-Stinger/blob/main/User_Mods/MMU/Stinger%20Pico%20MMU%20-%20%40LH/Stinger%20Pico%20MMU.3mf))

* Stepper motor hold current default value in LH's repository is 0.4. See [source code](https://github.com/lhndo/LH-Stinger/blob/main/User_Mods/MMU/Stinger%20Pico%20MMU%20-%20%40LH/Klipper/sp_mmu.cfg#L60).

* Pico MMU's default behavior is to only have sync'ing between extruder and MMU gears during extruder loading phase. At all other times, during normal printing, the servo is disengaged (at 0º) and stepper motor is disabled.